### PR TITLE
Make compatible with Python 3

### DIFF
--- a/predpatt/UDParse.py
+++ b/predpatt/UDParse.py
@@ -43,7 +43,7 @@ class UDParse:
             cols[i % K].append(x)
         # add padding to columns because zip stops at shortest iterator.
         for c in cols:
-            c.extend('' for _ in xrange(len(cols[0]) - len(c)))
+            c.extend('' for _ in range(len(cols[0]) - len(c)))
         return tabulate(zip(*cols), tablefmt='plain')
 
     def latex(self):

--- a/predpatt/__main__.py
+++ b/predpatt/__main__.py
@@ -1,6 +1,9 @@
 """
 PredPatt command-line program.
 """
+
+from __future__ import print_function
+
 import sys, codecs
 from argparse import ArgumentParser
 from predpatt import PredPatt, PredPattOpts, load_conllu, load_comm
@@ -9,7 +12,8 @@ from predpatt import PredPatt, PredPattOpts, load_conllu, load_comm
 def main():
     # Make stdout utf-8 friendly. This is only really needed when redirecting stdout
     # to a file or less.
-    sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
+    if sys.version_info[0] == 2:
+        sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
 
     parser = ArgumentParser()
     parser.add_argument('filename',
@@ -44,18 +48,17 @@ def main():
     for sent_i, (slabel, parse) in enumerate(sentences, 1):
         if args.debug and slabel != args.debug:  # supports substring match
             continue
-
-        print 'label:   ', slabel
-        print 'sentence:', ' '.join(parse.tokens)
+        print('label:   ', slabel)
+        print('sentence:', ' '.join(parse.tokens))
 
         if args.debug:
             args.show_deps = True
 
         if args.show_deps:
-            print
-            print 'tags:', ' '.join('%s/%s' % (x, tag) for tag, x in zip(parse.tags, parse.tokens))
-            print
-            print parse.pprint(args.format=='color', K=args.show_deps_cols)
+            print()
+            print('tags:', ' '.join('%s/%s' % (x, tag) for tag, x in list(zip(parse.tags, parse.tokens))))
+            print()
+            print(parse.pprint(args.format=='color', K=args.show_deps_cols))
 
         opts = PredPattOpts(simple = args.simple,
                             cut = args.cut,
@@ -69,12 +72,12 @@ def main():
 
         #ppatt.instances = [e for e in ppatt.instances if filter_events_ksk(e, parse)]
 
-        print
-        print 'ppatt:'
-        print ppatt.pprint(color=args.format == 'color',
-                           track_rule=args.track_rule)
-        print
-        print
+        print()
+        print('ppatt:')
+        print(ppatt.pprint(color=args.format == 'color',
+                           track_rule=args.track_rule))
+        print()
+        print()
 
         if args.debug or sent_i == args.num:
             return

--- a/predpatt/patt.py
+++ b/predpatt/patt.py
@@ -7,6 +7,7 @@ https://universaldependencies.github.io/docs/u/dep/index.html
 
 """
 from __future__ import unicode_literals
+from builtins import chr, str
 
 import itertools
 from termcolor import colored
@@ -51,7 +52,7 @@ def argument_names(args):
     name = {}
     for i, arg in enumerate(args):
         c = i // 26 if i >= 26 else ''
-        name[arg] = '?%s%s' % (unichr(97+(i % 26)), c)
+        name[arg] = '?%s%s' % (chr(97+(i % 26)), c)
     return name
 
 def sort_by_position(x):
@@ -269,7 +270,7 @@ class Predicate(object):
         # Format predicate
         rule = ''
         if track_rule:
-            rule = ',%s' % ','.join(sorted(map(unicode, self.rules)))
+            rule = ',%s' % ','.join(sorted(map(str, self.rules)))
         lines.append('%s%s%s'
                      % (indent, self._format_predicate(name, C=C),
                         C('%s[%s-%s%s]' % (indent, self.root.text,
@@ -284,7 +285,7 @@ class Predicate(object):
                 s = C(arg.phrase(), 'green')
             rule = ''
             if track_rule:
-                rule = ',%s' % ','.join(sorted(map(unicode, arg.rules)))
+                rule = ',%s' % ','.join(sorted(map(str, arg.rules)))
             lines.append('%s%s: %s%s'
                          % (indent*2, name[arg], s,
                             C('%s[%s-%s%s]' % (indent, arg.root.text,
@@ -333,9 +334,9 @@ def convert_parse(parse, ud):
         tokens[i].gov = (None if i not in parse.governor or parse.governor[i].gov == -1
                          else tokens[parse.governor[i].gov])
         tokens[i].gov_rel = parse.governor[i].rel if i in parse.governor else 'root'
-        tokens[i].dependents = map(convert_edge, parse.dependents[i])
+        tokens[i].dependents = [convert_edge(e) for e in parse.dependents[i]]
 
-    return UDParse(tokens, parse.tags, map(convert_edge, parse.triples), ud)
+    return UDParse(tokens, parse.tags, [convert_edge(e) for e in parse.triples], ud)
 
 
 _PARSER = None
@@ -506,7 +507,7 @@ class PredPatt(object):
                         nominate(e.gov, R.c(e))
 
         # Add all conjoined predicates
-        q = roots.values()
+        q = list(roots.values())
         while q:
             gov = q.pop()
             for e in gov.root.dependents:

--- a/predpatt/rules.py
+++ b/predpatt/rules.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 class Rule(object):
     def __init__(self):
         pass
@@ -364,4 +366,4 @@ class en_relcl_dummy_arg_filter(EnglishSpecific):
 
 
 if __name__ == '__main__':
-    print a1(), a1().explain()
+    print(a1(), a1().explain())

--- a/predpatt/util/load.py
+++ b/predpatt/util/load.py
@@ -58,7 +58,9 @@ def load_conllu(filename):
                 continue
             assert len(line) == 10, line
             lines.append(line)
-        [_, tokens, _, tags, _, _, gov, gov_rel, _, _] = zip(*lines)
+            print('lines')
+            print(lines)
+        [_, tokens, _, tags, _, _, gov, gov_rel, _, _] = list(zip(*lines))
         triples = [DepTriple(rel, int(gov)-1, dep) for dep, (rel, gov) in enumerate(zip(gov_rel, gov))]
         parse = UDParse(list(tokens), tags, triples)
         yield sent_id, parse

--- a/predpatt/util/load.py
+++ b/predpatt/util/load.py
@@ -58,8 +58,6 @@ def load_conllu(filename):
                 continue
             assert len(line) == 10, line
             lines.append(line)
-            print('lines')
-            print(lines)
         [_, tokens, _, tags, _, _, gov, gov_rel, _, _] = list(zip(*lines))
         triples = [DepTriple(rel, int(gov)-1, dep) for dep, (rel, gov) in enumerate(zip(gov_rel, gov))]
         parse = UDParse(list(tokens), tags, triples)

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,6 @@ setup(name='predpatt',
                         'bottle',
                         'tabulate',
                         'PyStanfordDependencies',
-                        'jpype1']
+                        'jpype1',
+                        'future']
 )

--- a/test/doctest.py
+++ b/test/doctest.py
@@ -1,6 +1,9 @@
 """
 Documentation test runner.
 """
+
+from __future__ import print_function
+
 import re, codecs
 from predpatt import PredPatt, PredPattOpts, Parser
 from termcolor import colored
@@ -78,30 +81,30 @@ def test():
             #print colored('pass', 'green')
             passed += 1
         else:
-            print
-            print colored('> ' + s, 'yellow')
-            print colored('fail', 'red')
-            print 'expected:'
+            print()
+            print(colored('> ' + s, 'yellow'))
+            print(colored('fail', 'red'))
+            print('expected:')
             for line in expected.split('\n'):
-                print '   ', colored(line, 'blue')
-            print 'got:'
+                print('   ', colored(line, 'blue'))
+            print('got:')
             for line in got.split('\n'):
-                print '   ', line
-            print
-            print colored(tags, 'magenta')
-            print
-            print colored(parse, 'magenta')
+                print('   ', line)
+            print()
+            print(colored(tags, 'magenta'))
+            print()
+            print(colored(parse, 'magenta'))
             failed += 1
 
     msg = '[doctest] %.f%% (%s/%s) passed' % (passed * 100.0 / (passed+failed), passed, passed+failed)
     if failed == 0:
-        print msg
+        print(msg)
     else:
-        print
-        print msg
-        print
+        print()
+        print(msg)
+        print()
         if blank:
-            print 'blank:', blank
+            print('blank:', blank)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I made some small changes to make the code usable with both Python 2 and 3. These largely consisted of using the print function and handling some differences with str/bytes that changed between Python 2 and 3. Also added the [future](https://pypi.python.org/pypi/future) library as a dependency.