### PR TITLE
Fix demo error related to ud version being '1.0'

### DIFF
--- a/bin/server.py
+++ b/bin/server.py
@@ -38,7 +38,7 @@ def main():
 
     pp_opts = PredPattOpts()
     for k, v in sorted(PredPattOpts().__dict__.iteritems()):
-        v = int(request.GET.get(k, v))   # all options are true/false for now.
+        v = int(float(request.GET.get(k, v)))   # all options are true/false for now.
         setattr(pp_opts, k, v)
 
     if sentence:


### PR DESCRIPTION
By default, `dep_v1.Version` is the float 1.0 represented as a string
https://github.com/hltcoe/PredPatt/blob/ac827992e7f81584016975c497f0f20f2722032a/predpatt/patt.py#L310
https://github.com/hltcoe/PredPatt/blob/ac827992e7f81584016975c497f0f20f2722032a/predpatt/util/ud.py#L34

This causes an error when casting the value to an int. I added  v = int(float(request.GET.get(k, v))) to first cast all string values to floats and then ints.